### PR TITLE
[Bugfix] Missing export for AntDevice on index.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import Channel from './ant-channel'
 export {Channel}
 export {Constants} from './consts'
 export {Messages} from './messages'
+export {AntDevice} from './ant-device';
 export * from './sensors'
 
 export {ChannelProps, IAntDevice, IChannel, ISensor} from './types'


### PR DESCRIPTION
Hi,

I've noticed that the `AntDevice` class is not exposed in the `index.ts` file.  So the example code snippets are not working. 

```ts
const {AntDevice} = require('incyclist-ant-plus')

const ant = new AntDevice({startupTimeout:2000})
const success = await ant.open()
```

